### PR TITLE
Close apps when VPN disconnected in strict mode.

### DIFF
--- a/VPNWatcher-Source/MainWindow.xaml.cs
+++ b/VPNWatcher-Source/MainWindow.xaml.cs
@@ -167,6 +167,8 @@ namespace VPNWatcher
                 iconAction(STATUS.VPN_CONNECTED);
                 return true;
             }
+
+            performApplicationAction();
             return false;
         }
 


### PR DESCRIPTION
Strict Mode primarily differs from "regular" mode in that it will consider a VPN connection terminated if the network adapter is no longer detected.

This change permits the application terminating behaviour to function if the adapter is removed on disconnect (e.g. by NordVPN's service)